### PR TITLE
Add dump() method on RuntimeSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to
 
 ### Added
 - settings:
-  - Add `dump()` method on to print se
+  - Add `dump()` method on `RuntimeSettings` class to print all settings with
+    their value and origin on standard output.
   - Add `name` attribute on `SettingsDefinitionLoaderYaml` and
     `RuntimeSettingsSiteLoaderIni` classes.
   - Add `_origin` dict attribute on `RuntimeSettingsSection` to keep tracks of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+- settings:
+  - Add `dump()` method on to print se
+  - Add `name` attribute on `SettingsDefinitionLoaderYaml` and
+    `RuntimeSettingsSiteLoaderIni` classes.
+  - Add `_origin` dict attribute on `RuntimeSettingsSection` to keep tracks of
+    origin of parameters values.
+
 ## [1.0.3] - 2024-08-30
 
 ### Added

--- a/src/settings/rfl/settings/definition.py
+++ b/src/settings/rfl/settings/definition.py
@@ -21,6 +21,7 @@ class SettingsDefinitionLoaderYaml(SettingsDefinitionLoader):
         try:
             if raw is not None:
                 self.content = yaml.safe_load(raw)
+                self.name = "definition:yaml:raw"
             elif path is not None:
                 try:
                     with open(path) as fh:
@@ -29,6 +30,7 @@ class SettingsDefinitionLoaderYaml(SettingsDefinitionLoader):
                     raise SettingsDefinitionError(
                         f"Settings definition file {path} not found"
                     ) from err
+                self.name = f"def:yaml:{path}"
             else:
                 raise SettingsDefinitionError(
                     "Either a raw string value or a path must be given to load YAML "
@@ -183,6 +185,7 @@ class SettingsSectionDefinition:
 
 class SettingsDefinition:
     def __init__(self, loader: SettingsDefinitionLoader):
+        self.loader = loader
         self.sections = [
             SettingsSectionDefinition(section, parameters)
             for section, parameters in loader.content.items()

--- a/src/settings/rfl/settings/loaders.py
+++ b/src/settings/rfl/settings/loaders.py
@@ -26,9 +26,11 @@ class RuntimeSettingsSiteLoaderIni(RuntimeSettingsSiteLoader):
             if raw is not None:
                 logger.debug("Loading site settings in INI format from raw value")
                 self.content.read_string(raw)
+                self.name = "site:ini:raw"
             elif path is not None:
                 logger.debug("Loading site settings file %s", path)
                 self.content.read(path)
+                self.name = f"site:ini:{path}"
             else:
                 raise SettingsSiteLoaderError(
                     "Either a raw string value or a path must be given to load site "


### PR DESCRIPTION
This method can be used to print all settings with their value and origin on standard output.