### PR TITLE
chore(ci): update ubuntu/python version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,10 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
+          - os: "ubuntu-22.04"
+            python-version: "3.7"
           - os: "ubuntu-20.04"
             python-version: "3.6"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
On Github, ubuntu-latest is now ubuntu-24.04 and does not support 3.7 anymore. Force ubuntu-22.04 for 3.7, and add 3.13 on ubuntu-latest.