### PR TITLE
fix: adopt PEP 639 with SPDX license

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
 
+      # The version of setuptools in python 3.8 environment does not support PEP 639
+      # license metadata format. Patch pyproject.toml for this version to restore old
+      # deprecated format.
+      - name: Patch license metadata (Python 3.8)
+        if: ${{ matrix.python-version == '3.8' }}
+        run: |
+          sed -i 's/^license = \(".*"\)/license = {text = \1}/' pyproject.toml src/*/pyproject.toml
+
       - name: Install application
         run: |
           pip install src/core src/authentication src/build src/log src/permissions src/settings src/web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
   user authentication to retrieve user information and groups (#57).
   Contribution from @Cornelicorn.
 
+### Fixed
+- pkg: Adopt PEP 639 to declare license in package metadata with SPDX notation
+  and fix deprecation notice raised by external build package (#52).
+
 ## [1.4.0] - 2025-04-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "RFL"
 version = "1.4.0"
 description = "Rackslab Foundation Library"
+license = "GPL-3.0-or-later"
 requires-python = ">=3.6"
 
 [tool.ruff.lint]

--- a/src/authentication/pyproject.toml
+++ b/src/authentication/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "RFL.authentication"
 version = "1.4.0"
 description = "Rackslab Foundation Library: authentication package"
-license = {text = "GPLv3+"}
+license = "GPL-3.0-or-later"
 requires-python = ">=3.6"
 keywords = ["utility", "basic"]
 authors = [
@@ -21,7 +21,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
     "Topic :: System :: Systems Administration",
 ]

--- a/src/build/pyproject.toml
+++ b/src/build/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "RFL.build"
 version = "1.4.0"
 description = "Rackslab Foundation Library: build package"
-license = {text = "GPLv3+"}
+license = "GPL-3.0-or-later"
 requires-python = ">=3.6"
 keywords = ["utility", "basic"]
 authors = [
@@ -20,7 +20,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
     "Topic :: System :: Systems Administration",
 ]

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "RFL.core"
 version = "1.4.0"
 description = "Rackslab Foundation Library: core package"
-license = {text = "GPLv3+"}
+license = "GPL-3.0-or-later"
 requires-python = ">=3.6"
 keywords = ["utility", "basic"]
 authors = [
@@ -17,7 +17,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
     "Topic :: System :: Systems Administration",
 ]

--- a/src/log/pyproject.toml
+++ b/src/log/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "RFL.log"
 version = "1.4.0"
 description = "Rackslab Foundation Library: log package"
-license = {text = "GPLv3+"}
+license = "GPL-3.0-or-later"
 requires-python = ">=3.6"
 keywords = ["utility", "basic"]
 authors = [
@@ -17,7 +17,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
     "Topic :: System :: Systems Administration",
 ]

--- a/src/permissions/pyproject.toml
+++ b/src/permissions/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "RFL.permissions"
 version = "1.4.0"
 description = "Rackslab Foundation Library: permissions package"
-license = {text = "GPLv3+"}
+license = "GPL-3.0-or-later"
 requires-python = ">=3.6"
 keywords = ["utility", "basic"]
 authors = [
@@ -21,7 +21,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
     "Topic :: System :: Systems Administration",
 ]

--- a/src/settings/pyproject.toml
+++ b/src/settings/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "RFL.settings"
 version = "1.4.0"
 description = "Rackslab Foundation Library: settings package"
-license = {text = "GPLv3+"}
+license = "GPL-3.0-or-later"
 requires-python = ">=3.6"
 keywords = ["utility", "basic"]
 authors = [
@@ -20,7 +20,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
     "Topic :: System :: Systems Administration",
 ]

--- a/src/web/pyproject.toml
+++ b/src/web/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "RFL.web"
 version = "1.4.0"
 description = "Rackslab Foundation Library: web package"
-license = {text = "GPLv3+"}
+license = "GPL-3.0-or-later"
 requires-python = ">=3.6"
 keywords = ["utility", "basic"]
 authors = [
@@ -21,7 +21,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
     "Topic :: System :: Systems Administration",
 ]


### PR DESCRIPTION
Fix license deprecation raised by external build package by adopting PEP 639 with SPDX license names.

fix #52