### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 ---
 name: Automated Tests
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rackslab/RFL/security/code-scanning/4](https://github.com/rackslab/RFL/security/code-scanning/4)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should be added at the root level of the workflow to apply to all jobs unless overridden by job-specific permissions. Based on the tasks performed in the workflow, the minimal permissions required are `contents: read`. This ensures that the workflow has only the necessary access to repository contents and does not inadvertently gain write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
