### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,6 +7,9 @@ on:
     - main
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rackslab/RFL/security/code-scanning/2](https://github.com/rackslab/RFL/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the provided steps, the workflow primarily checks out the repository, sets up Python, and runs pre-commit hooks. These actions typically require `contents: read` permissions. No write permissions are necessary unless explicitly required by the pre-commit action, which is not indicated in the provided snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
