### PR TITLE
chore: declare tests deps in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,18 @@ version = "1.6.0"
 description = "Rackslab Foundation Library"
 license = "LGPL-3.0-or-later"
 requires-python = ">=3.6"
+authors = [
+    {name = "Rémi Palancher", email = "remi@rackslab.io"},
+]
+
+[project.optional-dependencies]
+tests = [
+    "Flask",
+    "PyJWT",
+    "pytest",
+    "python-ldap",
+    "PyYAML",
+]
 
 [tool.ruff.lint]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.


### PR DESCRIPTION
Declare all optional tests dependencies in pyproject.toml, so packaging tool can discover this list and install all requirements automatically.